### PR TITLE
refactor: simplify date comparison in event filtering

### DIFF
--- a/src/components/molecules/UpcomingEvents.jsx
+++ b/src/components/molecules/UpcomingEvents.jsx
@@ -41,20 +41,12 @@ const eventsQuery = gql`
 const filterUpcomingEvents = (data) => {
   return data.allEvents.reduce((acc, event) => {
     if (!event.date) return acc
-    const date = new Date(event.date)
-    const today = new Date()
+    const date = DateTime.fromISO(event.date, { zone: 'utc' })
+    const today = DateTime.utc().startOf('day')
 
-    if (date.getFullYear() < today.getFullYear()) {
-      return acc
-    }
-    if (date.getFullYear() === today.getFullYear()) {
-      if (date.getMonth() < today.getMonth()) return acc
-      if (date.getMonth() === today.getMonth()) {
-        if (date.getDate() < today.getDate()) return acc
-      }
-    }
+    if (date < today) return acc
 
-    acc.push({ ...event, date: DateTime.fromSQL(event.date, { zone: 'utc' }) })
+    acc.push({ ...event, date })
     return acc
   }, [])
 }


### PR DESCRIPTION
## Summary

Refactored the `filterUpcomingEvents` function to use Luxon's `DateTime` API consistently and simplify date comparison logic.

## Key Changes

- Replaced native `Date` objects with Luxon `DateTime` for all date handling
- Simplified year/month/day comparison logic into a single `date < today` check
- Normalized `today` to start of day in UTC for consistent filtering
- Removed redundant `DateTime.fromSQL()` call by reusing the already-parsed `date` variable

## Implementation Details

The previous implementation manually compared year, month, and day components across two `Date` objects, which was verbose and error-prone. The new approach:

1. Parses the event date as a Luxon `DateTime` in UTC
2. Creates a `today` reference as the start of the current day in UTC
3. Uses Luxon's built-in comparison operators (`<`) to filter out past events

This aligns with the project's existing use of Luxon for date handling (as noted in the architecture docs) and reduces code complexity while maintaining the same filtering behavior.

https://claude.ai/code/session_0197SUzK7uxvMKyxQgkmoSMo